### PR TITLE
Require redis.

### DIFF
--- a/lib/grape/cache.rb
+++ b/lib/grape/cache.rb
@@ -2,6 +2,7 @@ require "grape/cache/patches"
 require "grape/cache/dsl"
 require "grape/cache/version"
 require "grape/cache/backend/memory"
+require "grape/cache/backend/redis"
 require "grape/cache/middleware"
 
 


### PR DESCRIPTION
I was getting a ```uninitialized constant Grape::Cache::Backend::Redis (NameError)``` when trying to use redis as a backend, and noticed ```grape/cache/backend/redis``` not being required.