### PR TITLE
fix for parameter cache_key

### DIFF
--- a/grape-cache.gemspec
+++ b/grape-cache.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "digest-murmurhash", "~> 1.1"
-  spec.add_runtime_dependency "grape", "~> 0.18.0"
+  spec.add_runtime_dependency "grape", "~> 0.19.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/grape/cache/endpoint_cache_config.rb
+++ b/lib/grape/cache/endpoint_cache_config.rb
@@ -58,7 +58,7 @@ module Grape
 
       private
       def cache_key_array(endpoint)
-        endpoint.declared(endpoint.params, {}, [])
+        endpoint.declared(endpoint.params)
       end
 
       def create_cache_key(endpoint)

--- a/lib/grape/cache/patches.rb
+++ b/lib/grape/cache/patches.rb
@@ -1,4 +1,4 @@
-# Updated for Grape 0.18
+# Updated for Grape 0.19
 
 require 'grape'
 


### PR DESCRIPTION
cache key generation did not take parameter into consideration we always ended up with the same md5

This pull request reverts and fixes this but some of the tests are no longer working and return "Tried to filter for declared parameters but none exist.",  this might be due to changes inside grape
https://github.com/ruby-grape/grape/pull/1142/files.  I'm not sure how we get those test passing again though.